### PR TITLE
Fix version restore mutation

### DIFF
--- a/components/version-footer.tsx
+++ b/components/version-footer.tsx
@@ -54,22 +54,22 @@ export const VersionFooter = ({
           disabled={isMutating}
           onClick={async () => {
             setIsMutating(true);
+            try {
+              await mutate(
+                `/api/document?id=${artifact.documentId}`,
+                async (currentDocuments?: Array<Document>) => {
+                  await fetch(`/api/document?id=${artifact.documentId}`, {
+                    method: 'PATCH',
+                    body: JSON.stringify({
+                      timestamp: getDocumentTimestampByIndex(
+                        documents,
+                        currentVersionIndex,
+                      ),
+                    }),
+                  });
 
-            mutate(
-              `/api/document?id=${artifact.documentId}`,
-              await fetch(`/api/document?id=${artifact.documentId}`, {
-                method: 'PATCH',
-                body: JSON.stringify({
-                  timestamp: getDocumentTimestampByIndex(
-                    documents,
-                    currentVersionIndex,
-                  ),
-                }),
-              }),
-              {
-                optimisticData: documents
-                  ? [
-                      ...documents.filter((document) =>
+                  return currentDocuments
+                    ? currentDocuments.filter((document) =>
                         isAfter(
                           new Date(document.createdAt),
                           new Date(
@@ -79,11 +79,31 @@ export const VersionFooter = ({
                             ),
                           ),
                         ),
-                      ),
-                    ]
-                  : [],
-              },
-            );
+                      )
+                    : [];
+                },
+                {
+                  optimisticData: documents
+                    ? [
+                        ...documents.filter((document) =>
+                          isAfter(
+                            new Date(document.createdAt),
+                            new Date(
+                              getDocumentTimestampByIndex(
+                                documents,
+                                currentVersionIndex,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ]
+                    : [],
+                  revalidate: false,
+                },
+              );
+            } finally {
+              setIsMutating(false);
+            }
           }}
         >
           <div>Restore this version</div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -143,11 +143,11 @@ export function getMostRecentUserMessage(messages: Array<UIMessage>) {
 }
 
 export function getDocumentTimestampByIndex(
-  documents: Array<Document>,
+  documents: Array<Document> | undefined,
   index: number,
 ) {
   if (!documents) return new Date();
-  if (index > documents.length) return new Date();
+  if (index < 0 || index >= documents.length) return new Date();
 
   return documents[index].createdAt;
 }


### PR DESCRIPTION
## Summary
- fix restore version logic to update documents correctly
- ensure the restoring indicator resets after the request

## Testing
- `pnpm test` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68402dea874c8324a22b67349058bdf1