### PR TITLE
Add number guessing game route

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useState } from 'react';
+
+export default function Page() {
+  const [target, setTarget] = useState(() => Math.floor(Math.random() * 100) + 1);
+  const [guess, setGuess] = useState('');
+  const [feedback, setFeedback] = useState('');
+
+  const handleGuess = () => {
+    const num = Number(guess);
+    if (Number.isNaN(num)) {
+      setFeedback('Enter a valid number!');
+      return;
+    }
+    if (num < target) setFeedback('Too low!');
+    else if (num > target) setFeedback('Too high!');
+    else setFeedback('Correct!');
+  };
+
+  const reset = () => {
+    setTarget(Math.floor(Math.random() * 100) + 1);
+    setGuess('');
+    setFeedback('');
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 p-8">
+      <h1 className="text-2xl font-bold">Guess the Number</h1>
+      <p>I'm thinking of a number between 1 and 100.</p>
+      <input
+        className="border rounded px-2 py-1"
+        value={guess}
+        onChange={(e) => setGuess(e.target.value)}
+        placeholder="Enter your guess"
+      />
+      <button
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+        onClick={handleGuess}
+      >
+        Guess
+      </button>
+      {feedback && <p>{feedback}</p>}
+      <button className="underline text-sm" onClick={reset}>
+        New game
+      </button>
+    </div>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -27,22 +27,33 @@ export function AppSidebar({ user }: { user: User | undefined }) {
       <SidebarHeader>
         <SidebarMenu>
           <div className="flex flex-row justify-between items-center">
-            <Link
-              href="/"
-              onClick={() => {
-                setOpenMobile(false);
-              }}
-              className="flex flex-row gap-3 items-center"
-            >
-              <span className="text-lg font-semibold px-2 hover:bg-muted rounded-md cursor-pointer">
-                Chatbot
-              </span>
-            </Link>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  type="button"
+          <Link
+            href="/"
+            onClick={() => {
+              setOpenMobile(false);
+            }}
+            className="flex flex-row gap-3 items-center"
+          >
+            <span className="text-lg font-semibold px-2 hover:bg-muted rounded-md cursor-pointer">
+              Chatbot
+            </span>
+          </Link>
+          <Link
+            href="/game"
+            onClick={() => {
+              setOpenMobile(false);
+            }}
+            className="flex flex-row gap-3 items-center"
+          >
+            <span className="text-lg font-semibold px-2 hover:bg-muted rounded-md cursor-pointer">
+              Mini Game
+            </span>
+          </Link>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                type="button"
                   className="p-2 h-fit"
                   onClick={() => {
                     setOpenMobile(false);


### PR DESCRIPTION
## Summary
- add a simple number guessing mini game at `/game`
- link the game from the sidebar

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68402e0272688324be21a1bb42129a4a